### PR TITLE
fixes/Issue#5 resolves #5, closes #5

### DIFF
--- a/src/website/MCS.CM/Configuration/Configurator.cs
+++ b/src/website/MCS.CM/Configuration/Configurator.cs
@@ -3,6 +3,8 @@ using Feature.SitecoreForms.MarketingCategoriesSubscription.CM.Services;
 using Feature.SitecoreForms.MarketingCategoriesSubscription.Contract.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Sitecore.DependencyInjection;
+using Sitecore.EmailCampaign.Cd.Services;
+using IMarketingPreferencesService = Sitecore.EmailCampaign.Cd.Services.IMarketingPreferencesService;
 
 namespace Feature.SitecoreForms.MarketingCategoriesSubscription.CM.Configuration
 {
@@ -14,6 +16,14 @@ namespace Feature.SitecoreForms.MarketingCategoriesSubscription.CM.Configuration
         {
             serviceCollection.AddTransient<IExmSubscriptionClientApiService, ExmStandaloneSubscriptionClientApiService>();
             serviceCollection.AddTransient<ISubscribeContactService, SubscribeContactService>();
+
+            /*  ToDo:
+                Dirty workaround, the Sitecore.EmailCampaign.Cd.Services.MarketingPreferencesService is configured to
+                be only loaded on role "Standalone or ContentDelivery". If the instance is configured to "ContentManagement" only,
+                the Module will throw a NullReferenceException.
+                https://github.com/monkey-dsc/Feature.SitecoreForms.MarketingCategoriesSubscription/issues Issue #5
+            */
+            serviceCollection.AddTransient<IMarketingPreferencesService, MarketingPreferencesService>();
         }
     }
 }

--- a/src/website/MCS.CM/Feature.SitecoreForms.MarketingCategoriesSubscription.CM.csproj
+++ b/src/website/MCS.CM/Feature.SitecoreForms.MarketingCategoriesSubscription.CM.csproj
@@ -69,6 +69,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Sitecore.EmailCampaign.Cd" Version="9.2.0" />
       <PackageReference Include="Sitecore.EmailCampaign.Cm" Version="9.2.0" />
       <PackageReference Include="Sitecore.Kernel" Version="9.2.0">
           <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Configured the Sitecore.EmailCampaign.Cd.Services.MarketingPreferencesService to be loaded on a instance configured to "ContentManagement" only (Workaround)